### PR TITLE
Update CAP command for IRCv3.2 compatibility

### DIFF
--- a/src/Cap.php
+++ b/src/Cap.php
@@ -21,7 +21,7 @@ use WildPHP\Messages\Traits\PrefixTrait;
  *
  * Syntax: prefix CAP nickname command [:capabilities]
  *
- * This definition implements version 3.1 and 3.2 of the ircv3 capability negotiation spec
+ * This definition implements version 3.1 and 3.2 of the IRCv3 capability negotiation spec
  * as described in the following documents:
  * https://ircv3.net/specs/core/capability-negotiation-3.1.html
  * https://ircv3.net/specs/core/capability-negotiation-3.2.html
@@ -56,7 +56,7 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
     public function __construct(string $command, array $capabilities = [])
     {
         if (!in_array($command, ['LS', 'LIST', 'REQ', 'ACK', 'NAK', 'END', 'NEW', 'DEL']) && preg_match('/^LS \d{3}$/', $command) == false) {
-            throw new \InvalidArgumentException('Cap subcommand not valid');
+            throw new \InvalidArgumentException('Cap sub-command not valid');
         }
 
         $this->setCommand($command);

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -47,7 +47,7 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
      */
     public function __construct(string $command, array $capabilities = [])
     {
-        if (!in_array($command, ['LS', 'LIST', 'REQ', 'ACK', 'NAK', 'END'])) {
+        if (!in_array($command, ['LS', 'LIST', 'REQ', 'ACK', 'NAK', 'END']) && preg_match('/^LS \d{3}$/', $command) == false) {
             throw new \InvalidArgumentException('Cap subcommand not valid');
         }
 

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -55,7 +55,7 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
      */
     public function __construct(string $command, array $capabilities = [])
     {
-        if (!in_array($command, ['LS', 'LIST', 'REQ', 'ACK', 'NAK', 'END', 'NEW', 'DEL']) && preg_match('/^LS \d{3}$/', $command) == false) {
+        if (!in_array($command, ['LS', 'LIST', 'REQ', 'ACK', 'NAK', 'END', 'NEW', 'DEL']) && preg_match('/^LS \d{3}$/', $command) === 0) {
             throw new \InvalidArgumentException('Cap sub-command not valid');
         }
 

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -21,6 +21,11 @@ use WildPHP\Messages\Traits\PrefixTrait;
  * @package WildPHP\Messages
  *
  * Syntax: prefix CAP nickname command [:capabilities]
+ *
+ * This definition implements version 3.1 and 3.2 of the ircv3 capability negotiation spec
+ * as described in the following documents:
+ * https://ircv3.net/specs/core/capability-negotiation-3.1.html
+ * https://ircv3.net/specs/core/capability-negotiation-3.2.html
  */
 class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterface, OutgoingMessageInterface
 {

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -13,7 +13,6 @@ use WildPHP\Messages\Generics\Prefix;
 use WildPHP\Messages\Interfaces\IncomingMessageInterface;
 use WildPHP\Messages\Interfaces\IrcMessageInterface;
 use WildPHP\Messages\Interfaces\OutgoingMessageInterface;
-use WildPHP\Messages\Traits\NicknameTrait;
 use WildPHP\Messages\Traits\PrefixTrait;
 
 /**
@@ -30,7 +29,6 @@ use WildPHP\Messages\Traits\PrefixTrait;
 class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterface, OutgoingMessageInterface
 {
     use PrefixTrait;
-    use NicknameTrait;
 
     protected static $verb = 'CAP';
 
@@ -38,6 +36,11 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
      * @var string
      */
     protected $command = '';
+
+    /**
+     * @var string
+     */
+    protected $clientIdentifier = '';
 
     /**
      * @var array
@@ -73,12 +76,12 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
 
         $prefix = Prefix::fromIncomingMessage($incomingMessage);
         $args = $incomingMessage->getArgs();
-        $nickname = array_shift($args);
+        $clientIdentifier = array_shift($args);
         $command = array_shift($args);
         $capabilities = explode(' ', array_shift($args));
 
         $object = new self($command, $capabilities);
-        $object->setNickname($nickname);
+        $object->setClientIdentifier($clientIdentifier);
         $object->setPrefix($prefix);
 
         return $object;
@@ -124,5 +127,21 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
         $capabilities = implode(' ', $this->getCapabilities());
 
         return 'Cap ' . $this->getCommand() . (!empty($capabilities) ? ' :' . $capabilities : '') . "\r\n";
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientIdentifier(): string
+    {
+        return $this->clientIdentifier;
+    }
+
+    /**
+     * @param string $clientIdentifier
+     */
+    public function setClientIdentifier(string $clientIdentifier): void
+    {
+        $this->clientIdentifier = $clientIdentifier;
     }
 }

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -47,7 +47,7 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
      */
     public function __construct(string $command, array $capabilities = [])
     {
-        if (!in_array($command, ['LS', 'LIST', 'REQ', 'ACK', 'NAK', 'END']) && preg_match('/^LS \d{3}$/', $command) == false) {
+        if (!in_array($command, ['LS', 'LIST', 'REQ', 'ACK', 'NAK', 'END', 'NEW', 'DEL']) && preg_match('/^LS \d{3}$/', $command) == false) {
             throw new \InvalidArgumentException('Cap subcommand not valid');
         }
 

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -83,10 +83,14 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
 
         $prefix = Prefix::fromIncomingMessage($incomingMessage);
         $args = $incomingMessage->getArgs();
+        $isFinal = count($args) == 3;
         $clientIdentifier = array_shift($args);
         $command = array_shift($args);
+
+        if (!$isFinal)
+            array_shift($args);
+
         $capabilities = explode(' ', array_shift($args));
-        $isFinal = count($args) == 3;
 
         $object = new self($command, $capabilities, $isFinal);
         $object->setClientIdentifier($clientIdentifier);

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -126,7 +126,7 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
     {
         $capabilities = implode(' ', $this->getCapabilities());
 
-        return 'Cap ' . $this->getCommand() . (!empty($capabilities) ? ' :' . $capabilities : '') . "\r\n";
+        return 'CAP ' . $this->getCommand() . (!empty($capabilities) ? ' :' . $capabilities : '') . "\r\n";
     }
 
     /**

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -90,7 +90,7 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
         if (!$isFinal)
             array_shift($args);
 
-        $capabilities = explode(' ', array_shift($args));
+        $capabilities = explode(' ', trim(array_shift($args)));
 
         $object = new self($command, $capabilities, $isFinal);
         $object->setClientIdentifier($clientIdentifier);

--- a/tests/IrcMessageTest.php
+++ b/tests/IrcMessageTest.php
@@ -143,9 +143,13 @@ class IrcMessageTest extends TestCase
 
         $this->assertEquals('REQ', $cap->getCommand());
         $this->assertEquals(['cap1', 'cap2'], $cap->getCapabilities());
+        $this->assertTrue($cap->isFinalMessage());
 
         $expected = 'CAP REQ :cap1 cap2' . "\r\n";
         $this->assertEquals($expected, $cap->__toString());
+
+        $cap = new Cap('REQ', ['cap1', 'cap2'], false);
+        $this->assertFalse($cap->isFinalMessage());
     }
 
 	public function testCapCreateInvalidSubcommand()
@@ -168,6 +172,18 @@ class IrcMessageTest extends TestCase
         $this->assertEquals('LS', $cap->getCommand());
         $this->assertEquals(['cap1', 'cap2'], $cap->getCapabilities());
         $this->assertEquals('*', $cap->getClientIdentifier());
+        $this->assertTrue($cap->isFinalMessage());
+
+        $prefix = 'server';
+        $verb = 'CAP';
+        $args = ['*', 'LS', '*', 'cap1 cap2'];
+        $incoming = new IrcMessage($prefix, $verb, $args);
+        $cap = Cap::fromIncomingMessage($incoming);
+
+        $this->assertEquals('LS', $cap->getCommand());
+        $this->assertEquals(['cap1', 'cap2'], $cap->getCapabilities());
+        $this->assertEquals('*', $cap->getClientIdentifier());
+        $this->assertFalse($cap->isFinalMessage());
 
 	    $prefix = ':server';
 		$verb = 'TEEHEE';

--- a/tests/IrcMessageTest.php
+++ b/tests/IrcMessageTest.php
@@ -144,7 +144,7 @@ class IrcMessageTest extends TestCase
         $this->assertEquals('REQ', $cap->getCommand());
         $this->assertEquals(['cap1', 'cap2'], $cap->getCapabilities());
 
-        $expected = 'Cap REQ :cap1 cap2' . "\r\n";
+        $expected = 'CAP REQ :cap1 cap2' . "\r\n";
         $this->assertEquals($expected, $cap->__toString());
     }
 
@@ -165,7 +165,7 @@ class IrcMessageTest extends TestCase
 
         $this->assertEquals('LS', $cap->getCommand());
         $this->assertEquals(['cap1', 'cap2'], $cap->getCapabilities());
-        $this->assertEquals('*', $cap->getNickname());
+        $this->assertEquals('*', $cap->getClientIdentifier());
 
 	    $prefix = ':server';
 		$verb = 'TEEHEE';

--- a/tests/IrcMessageTest.php
+++ b/tests/IrcMessageTest.php
@@ -150,6 +150,8 @@ class IrcMessageTest extends TestCase
 
 	public function testCapCreateInvalidSubcommand()
 	{
+	    new Cap('LS 302');
+
 		$this->expectException(\InvalidArgumentException::class);
 		
 		new Cap('INVALID');


### PR DESCRIPTION
This adds support for the NEW and DEL subcommands and updates the LS subcommand so it can contain a version number when set.

It also fixes a few quirks, including a *breaking change* (renaming the nickname field to clientIdentifier).