### PR TITLE
Add support for IRCv3 message tags

### DIFF
--- a/src/Account.php
+++ b/src/Account.php
@@ -58,6 +58,7 @@ class Account extends BaseIRCMessageImplementation implements IncomingMessageInt
 
         $object = new self($accountName);
         $object->setPrefix($prefix);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Authenticate.php
+++ b/src/Authenticate.php
@@ -53,6 +53,7 @@ class Authenticate extends BaseIRCMessageImplementation implements IncomingMessa
         $response = $incomingMessage->getArgs()[0];
 
         $object = new self($response);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Away.php
+++ b/src/Away.php
@@ -60,6 +60,7 @@ class Away extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $object = new self($message);
         $object->setPrefix($prefix);
         $object->setNickname($prefix->getNickname());
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Cap.php
+++ b/src/Cap.php
@@ -75,6 +75,7 @@ class Cap extends BaseIRCMessageImplementation implements IncomingMessageInterfa
         $object = new self($command, $capabilities);
         $object->setNickname($nickname);
         $object->setPrefix($prefix);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Error.php
+++ b/src/Error.php
@@ -40,6 +40,7 @@ class Error extends BaseIRCMessageImplementation implements IncomingMessageInter
         $message = $incomingMessage->getArgs()[0];
         $object = new self();
         $object->setMessage($message);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Generics/BaseIRCMessageImplementation.php
+++ b/src/Generics/BaseIRCMessageImplementation.php
@@ -21,7 +21,7 @@ abstract class BaseIRCMessageImplementation implements IrcMessageImplementationI
      * Additional data to be sent with the message.
      * @var array
      */
-    protected $messageParameters = [];
+    protected $tags = [];
 
     /**
      * @return string
@@ -34,16 +34,16 @@ abstract class BaseIRCMessageImplementation implements IrcMessageImplementationI
     /**
      * @return array
      */
-    public function getMessageParameters(): array
+    public function getTags(): array
     {
-        return $this->messageParameters;
+        return $this->tags;
     }
 
     /**
-     * @param array $messageParameters
+     * @param array $tags
      */
-    public function setMessageParameters(array $messageParameters)
+    public function setTags(array $tags)
     {
-        $this->messageParameters = $messageParameters;
+        $this->tags = $tags;
     }
 }

--- a/src/Generics/IrcMessage.php
+++ b/src/Generics/IrcMessage.php
@@ -14,6 +14,11 @@ use WildPHP\Messages\Interfaces\IrcMessageInterface;
 class IrcMessage implements IrcMessageInterface
 {
     /**
+     * @var array
+     */
+    protected $tags = [];
+
+    /**
      * @var string
      */
     protected $prefix = '';
@@ -34,12 +39,14 @@ class IrcMessage implements IrcMessageInterface
      * @param string $prefix
      * @param string $verb
      * @param array $args
+     * @param array $tags
      */
-    public function __construct(string $prefix, string $verb, array $args = [])
+    public function __construct(string $prefix, string $verb, array $args = [], array $tags = [])
     {
         $this->setPrefix($prefix);
         $this->setVerb($verb);
         $this->setArgs(array_values($args));
+        $this->setTags($tags);
     }
 
     /**
@@ -88,5 +95,21 @@ class IrcMessage implements IrcMessageInterface
     public function setArgs(array $args)
     {
         $this->args = $args;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param array $tags
+     */
+    public function setTags(array $tags): void
+    {
+        $this->tags = $tags;
     }
 }

--- a/src/Interfaces/IrcMessageInterface.php
+++ b/src/Interfaces/IrcMessageInterface.php
@@ -39,4 +39,14 @@ interface IrcMessageInterface
      * @param array $args
      */
     public function setArgs(array $args);
+
+    /**
+     * @return array
+     */
+    public function getTags(): array;
+
+    /**
+     * @param array $tags
+     */
+    public function setTags(array $tags);
 }

--- a/src/Join.php
+++ b/src/Join.php
@@ -98,6 +98,7 @@ class Join extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $object->setNickname($prefix->getNickname());
         $object->setIrcAccount($ircAccount);
         $object->setRealname($realname);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Kick.php
+++ b/src/Kick.php
@@ -75,6 +75,7 @@ class Kick extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $object = new self($channel, $target, $message);
         $object->setPrefix($prefix);
         $object->setNickname($prefix->getNickname());
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Mode.php
+++ b/src/Mode.php
@@ -84,6 +84,7 @@ class Mode extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $object = new self($target, $flags, $args);
         $object->setPrefix($prefix);
         $object->setNickname($prefix->getNickname());
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Nick.php
+++ b/src/Nick.php
@@ -64,6 +64,7 @@ class Nick extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $object = new self($newNickname);
         $object->setPrefix($prefix);
         $object->setNickname($nickname);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Notice.php
+++ b/src/Notice.php
@@ -67,6 +67,7 @@ class Notice extends BaseIRCMessageImplementation implements IncomingMessageInte
         $object = new self($channel, $message);
         $object->setPrefix($prefix);
         $object->setNickname($prefix->getNickname());
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Part.php
+++ b/src/Part.php
@@ -73,6 +73,7 @@ class Part extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $object = new self($channel, $message);
         $object->setPrefix($prefix);
         $object->setNickname($prefix->getNickname());
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Ping.php
+++ b/src/Ping.php
@@ -54,7 +54,10 @@ class Ping extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $server1 = $args[0];
         $server2 = $args[1] ?? '';
 
-        return new self($server1, $server2);
+        $object = new self($server1, $server2);
+        $object->setTags($incomingMessage->getTags());
+
+        return $object;
     }
 
     /**

--- a/src/Pong.php
+++ b/src/Pong.php
@@ -55,7 +55,10 @@ class Pong extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $server1 = $args[0];
         $server2 = $args[1] ?? '';
 
-        return new self($server1, $server2);
+        $object = new self($server1, $server2);
+        $object->setTags($incomingMessage->getTags());
+
+        return $object;
     }
 
     /**

--- a/src/Privmsg.php
+++ b/src/Privmsg.php
@@ -87,6 +87,7 @@ class Privmsg extends BaseIRCMessageImplementation implements IncomingMessageInt
         $object->setIsCtcp($isCtcp);
         $object->setCtcpVerb($ctcpVerb);
         $object->setNickname($prefix->getNickname());
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Quit.php
+++ b/src/Quit.php
@@ -61,6 +61,7 @@ class Quit extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $object = new self($message);
         $object->setPrefix($prefix);
         $object->setNickname($nickname);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/RPL/EndOfNames.php
+++ b/src/RPL/EndOfNames.php
@@ -50,6 +50,7 @@ class EndOfNames extends BaseIRCMessageImplementation implements IncomingMessage
         $object->setNickname($nickname);
         $object->setChannel($channel);
         $object->setMessage($message);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/RPL/ISupport.php
+++ b/src/RPL/ISupport.php
@@ -60,6 +60,7 @@ class ISupport extends BaseIRCMessageImplementation implements IncomingMessageIn
         $object->setServer($server);
         $object->setVariables($variables);
         $object->setMessage($message);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/RPL/NamReply.php
+++ b/src/RPL/NamReply.php
@@ -57,6 +57,7 @@ class NamReply extends BaseIRCMessageImplementation implements IncomingMessageIn
         $object->setChannel($channel);
         $object->setNicknames($nicknames);
         $object->setServer($server);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/RPL/Topic.php
+++ b/src/RPL/Topic.php
@@ -53,6 +53,7 @@ class Topic extends BaseIRCMessageImplementation implements IncomingMessageInter
         $object->setChannel($channel);
         $object->setMessage($message);
         $object->setServer($server);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/RPL/Welcome.php
+++ b/src/RPL/Welcome.php
@@ -48,6 +48,7 @@ class Welcome extends BaseIRCMessageImplementation implements IncomingMessageInt
         $object->setNickname($nickname);
         $object->setServer($server);
         $object->setMessage($message);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/RPL/WhosPcRpl.php
+++ b/src/RPL/WhosPcRpl.php
@@ -84,6 +84,7 @@ class WhosPcRpl extends BaseIRCMessageImplementation implements IncomingMessageI
         $object->setStatus($status);
         $object->setAccountname($accountname);
         $object->setServer($server);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Topic.php
+++ b/src/Topic.php
@@ -60,6 +60,7 @@ class Topic extends BaseIRCMessageImplementation implements IncomingMessageInter
 
         $object = new self($channel, $message);
         $object->setPrefix($prefix);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/User.php
+++ b/src/User.php
@@ -79,6 +79,7 @@ class User extends BaseIRCMessageImplementation implements IncomingMessageInterf
         $realname = array_shift($args);
 
         $object = new self($username, $hostname, $servername, $realname);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/src/Who.php
+++ b/src/Who.php
@@ -65,6 +65,7 @@ class Who extends BaseIRCMessageImplementation implements IncomingMessageInterfa
 
         $object = new self($channel, $options);
         $object->setPrefix($prefix);
+        $object->setTags($incomingMessage->getTags());
 
         return $object;
     }

--- a/tests/IrcMessageTest.php
+++ b/tests/IrcMessageTest.php
@@ -915,8 +915,8 @@ class IrcMessageTest extends TestCase
 	{
 		$raw = new Raw('test');
 		
-		$raw->setMessageParameters(['test']);
+		$raw->setTags(['test']);
 		
-		self::assertEquals(['test'], $raw->getMessageParameters());
+		self::assertEquals(['test'], $raw->getTags());
 	}
 }


### PR DESCRIPTION
IRCv3 adds support for message tags. This PR allows these tags to be stored in the IRC message implementations.

No changes should be made for messages which are only outgoing, since tags cannot be used on outgoing messages. Neither should the toString method be updated on any message.