### PR TITLE
MyInfo message now accepts only 5 parameters

### DIFF
--- a/src/RPL/MyInfo.php
+++ b/src/RPL/MyInfo.php
@@ -58,15 +58,22 @@ class MyInfo extends BaseIRCMessageImplementation implements IncomingMessageInte
             ));
         }
 
-        [$nickname, $server, $version, $userModes, $channelModes, $channelModesParam] = $incomingMessage->getArgs();
+        [
+          $nickname,
+          $server,
+          $version,
+          $userModes,
+          $channelModes,
+          $channelModesParam,
+        ] = $incomingMessage->getArgs() + [5 => ''];
 
         $object = new self();
         $object->setNickname($nickname);
         $object->setServer($server);
         $object->setVersion($version);
-        $object->setUserModes(str_split($userModes));
-        $object->setChannelModes(str_split($channelModes));
-        $object->setChannelModesWithParameter(str_split($channelModesParam));
+        $object->setUserModes(array_filter(str_split($userModes)));
+        $object->setChannelModes(array_filter(str_split($channelModes)));
+        $object->setChannelModesWithParameter(array_filter(str_split($channelModesParam)));
         $object->setTags($incomingMessage->getTags());
 
         return $object;

--- a/tests/MyInfoTest.php
+++ b/tests/MyInfoTest.php
@@ -31,6 +31,22 @@ class MyInfoTest extends TestCase
         $this->assertEquals(['g', 'h', 'i'], $rpl_welcome->getChannelModesWithParameter());
     }
 
+    public function testFromIncomingMessageWithFiveParameters(): void
+    {
+        $prefix = 'server';
+        $verb = '004';
+        $args = ['nickname', 'server', '1.0', 'abc', 'def'];
+        $incoming = new IrcMessage($prefix, $verb, $args);
+        $rpl_welcome = MyInfo::fromIncomingMessage($incoming);
+
+        $this->assertEquals('server', $rpl_welcome->getServer());
+        $this->assertEquals('nickname', $rpl_welcome->getNickname());
+        $this->assertEquals('1.0', $rpl_welcome->getVersion());
+        $this->assertEquals(['a', 'b', 'c'], $rpl_welcome->getUserModes());
+        $this->assertEquals(['d', 'e', 'f'], $rpl_welcome->getChannelModes());
+        $this->assertEquals([], $rpl_welcome->getChannelModesWithParameter());
+    }
+
     public function testFromIncomingMessageThrowsException(): void
     {
         $prefix = ':server';


### PR DESCRIPTION
This fixes https://github.com/WildPHP/irc-bot/issues/162 and makes the message adhere better to the protocol specification.